### PR TITLE
Fixed patient not being able to create

### DIFF
--- a/GlucoseGurusWebApi.WebApi/Controllers/PatientController.cs
+++ b/GlucoseGurusWebApi.WebApi/Controllers/PatientController.cs
@@ -82,17 +82,17 @@ namespace GlucoseGurusWebApi.WebApi.Controllers
             if (parentGuardian == null || parentGuardian.UserId != userId)
                 return NotFound($"ParentGuardian does not belong to the current user.");
 
-            var traject = await _trajectRepository.ReadAsync(trajectId);
+            var traject = await _trajectRepository.ReadAsync(newPatient.TrajectId);
             if (traject == null)
                 return NotFound($"Traject does not exist.");
 
-            var doctor = await _doctorRepository.ReadAsync(doctorId);
+            var doctor = await _doctorRepository.ReadAsync(newPatient.DoctorId);
             if (doctor == null)
                 return NotFound($"Doctor does not exist.");
 
-            newPatient.ParentGuardianId = parentGuardianId;
-            newPatient.TrajectId = trajectId;
-            newPatient.DoctorId = doctorId;
+            //newPatient.ParentGuardianId = parentGuardianId;
+            //newPatient.TrajectId = trajectId;
+            //newPatient.DoctorId = doctorId;
             var patient = await _patientRepository.InsertAsync(newPatient);
             return CreatedAtRoute("readPatient", new { patientId = patient.Id }, patient);
         }

--- a/GlucoseGurusWebApi.WebApi/Repositories/SqlPatientRepository.cs
+++ b/GlucoseGurusWebApi.WebApi/Repositories/SqlPatientRepository.cs
@@ -17,7 +17,7 @@ namespace GlucoseGurusWebApi.WebApi.Repositories
         {
             using (var sqlConnection = new SqlConnection(sqlConnectionString))
             {
-                var patientId = await sqlConnection.ExecuteAsync("INSERT INTO [Patient] (Id, FirstName, LastName, Avatar, ParentGuardianId, TracjectId, DocterId) VALUES (@Id, @FirstName, @LastName, @Avatar, @ParentGuardianId, @TracjectId, @DocterId)", patient);
+                var patientId = await sqlConnection.ExecuteAsync("INSERT INTO [Patient] (Id, FirstName, LastName, Avatar, ParentGuardianId, TrajectId, DoctorId) VALUES (@Id, @FirstName, @LastName, @Avatar, @ParentGuardianId, @TrajectId, @DoctorId)", patient);
                 return patient;
             }
         }


### PR DESCRIPTION
## Summary by Sourcery

Fix patient creation process by using patient object's properties instead of method parameters

Bug Fixes:
- Corrected patient creation logic to use the new patient object's TrajectId and DoctorId instead of method parameters

Enhancements:
- Updated SQL insert statement to use correct column names (TrajectId and DoctorId)